### PR TITLE
Fix: Use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: "Whether to notify user watching the Jira issues, default is 'false'"
     required: false
 runs:
-  using: 'node21'
+  using: 'node20'
   main: './dist/index.js'


### PR DESCRIPTION
use node20

In this PR https://github.com/Staffbase/github-action-jira-release-tagging/pull/114/files I changed the used node version for the action to node21. This was wrong as stated in the frontend workflow now

https://github.com/Staffbase/frontend/actions/runs/8249283571/job/22561334164
````
Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. 
(Parameter ''using: node21' is not supported, use 'docker', 'node12', 'node16' or 'node20' instead.')
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Failed to load Staffbase/github-action-jira-release-tagging/v1.3.0/action.yml
````

TODOs
- [ ] create new version and add it to the gha-workflow + create new github action workflow

### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

<!-- Please describe your pull request -->

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
