### PR TITLE
Fix docs regarding JIRA_BASEURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A GitHub action that uses a tag name and a list of Issue-IDs and updates their r
 
 ### Environment variables
 
-- `JIRA_BASEURL` - base url of jira (e.g. https://instance.atlassian.net/jira)
+- `JIRA_BASEURL` - base url of jira (default: https://mitarbeiterapp.atlassian.net)
 - `JIRA_TOKEN` - api token to use for Jira
 - `JIRA_EMAIL` - email of the owner of the Jira api token
 


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [x] Documentation

### Description

- Fix docs regarding JIRA_BASEURL
- It's actually predefined in `jira.js`