### PR TITLE
fix(deps): bump minimatch 3.x to 3.1.5 to resolve CVE-2026-27903

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5239,9 +5239,9 @@ minimatch@^10.1.1, minimatch@^10.2.4:
     brace-expansion "^5.0.2"
 
 minimatch@^3.0.4, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
The 3.1.2 copy of minimatch (pulled in transitively by the eslint
tooling) is affected by GHSA-7r86-cg39-jmmj: a ReDoS in matchOne()
via combinatorial backtracking with multiple non-adjacent GLOBSTAR
segments. The advisory patches the 3.x line in 3.1.3; bumping to the
latest 3.x patch (3.1.5) resolves the Dependabot alert. No dependency
changes (brace-expansion ^1.1.7 unchanged).

The minimatch 10.2.4 already present is >= the advisory's 10.x patch
(10.2.3) and is not affected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KDwkTakY5YCdiZgTss3H7j